### PR TITLE
Development of waltham

### DIFF
--- a/src/waltham/marshaller.h
+++ b/src/waltham/marshaller.h
@@ -34,6 +34,7 @@
 #include <sys/uio.h>
 #include <sys/un.h>
 #include <errno.h>
+#include <signal.h>
 
 #include "message.h"
 #include "marshaller_log.h"
@@ -42,7 +43,14 @@ static inline int send_all (int sock, const struct iovec *iov, int iovcnt)
 {
    int ret;
 
+   signal(SIGPIPE, SIG_IGN);
+
    do {
+      if (errno == EPIPE) {
+         fprintf(stderr, "send_all %d : %s\n", ret, strerror(errno));
+         errno = 0;
+         ret = 0;
+      }
       ret = writev (sock, iov, iovcnt);
    } while (ret == -1 && errno == EINTR);
 

--- a/src/waltham/marshaller_log.h
+++ b/src/waltham/marshaller_log.h
@@ -27,10 +27,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <waltham-connection.h>
 
 /* Comment/uncomment to disable/enable debugging log */
 #define DEBUG
 //#define PROFILE
+int debug_message;
 
 #ifdef DEBUG
 static inline void DEBUG_STAMP (void) {
@@ -45,15 +47,17 @@ static inline void DEBUG_STAMP (void) {
 }
 
 static inline void DEBUG_TYPE (const char *type) {
-   printf (" %s\n", type);
+   if(debug_message == 1)
+      printf (" %s\n", type);
 }
 
 static inline void STREAM_DEBUG( unsigned char *data, int sz, char *preamble ){
    int itr;
    unsigned char *p = data;
-   for( itr = 0; itr < sz; itr++ ){
-       printf( "%02x", p[itr] );
-   }
+   if(debug_message == 1)
+      for( itr = 0; itr < sz; itr++ ){
+         printf( "%02x", p[itr] );
+      }
 }
 
 static inline void STREAM_DEBUG_DATA (unsigned char *data, int sz) {

--- a/src/waltham/waltham-connection.c
+++ b/src/waltham/waltham-connection.c
@@ -38,6 +38,8 @@
 #include "waltham-private.h"
 #include "waltham-util.h"
 
+int debug_message = 0;
+
 struct wth_connection {
 	int fd;
 	enum wth_connection_side side;
@@ -62,11 +64,16 @@ wth_connect_to_server(const char *host, const char *port)
 {
 	struct wth_connection *conn = NULL;
 	int fd;
+	char *debug;
 
 	fd = connect_to_host(host, port);
 
 	if (fd >= 0)
 		conn = wth_connection_from_fd(fd, WTH_CONNECTION_SIDE_CLIENT);
+
+	debug = getenv("WALTHAM_DEBUG");
+	if(debug && (strcmp(debug, "1") == 0))
+		debug_message = 1;
 
 	return conn;
 }

--- a/src/waltham/waltham-connection.h
+++ b/src/waltham/waltham-connection.h
@@ -36,6 +36,8 @@
 extern "C" {
 #endif
 
+extern int debug_message;
+
 /** \file
  *
  * \brief Waltham connection management API

--- a/src/waltham/waltham-util.c
+++ b/src/waltham/waltham-util.c
@@ -49,9 +49,11 @@ wth_debug(const char *fmt, ...)
 {
 	va_list argp;
 
-	va_start(argp, fmt);
-	wth_pfx_print("debug", fmt, argp);
-	va_end(argp);
+	if(debug_message == 1) {
+		va_start(argp, fmt);
+		wth_pfx_print("debug", fmt, argp);
+		va_end(argp);
+	}
 }
 
 void


### PR DESCRIPTION
This introduce 3 patchs
 -1d09d12 waltham-connection: enable wth_connection_flush
    Introduce flush API to reduce write call. 
 
-8107a8b debug message: introduce configurable debug message
    Enable to switch waltham debug message on/off by environment variable. 

-ff9c8a4 marshaller: Fix when SIGPIPE is caught in send _all().
     Avoid to exit with SIGPIPE.
     This is necessary for retry connection usecase.
