### PR TITLE
0.1.0 devel protocol expansion

### DIFF
--- a/data/command.xml
+++ b/data/command.xml
@@ -1560,11 +1560,11 @@
     </event>
   </interface>
 
-  <interface name="ivi_surface" version="1">
+  <interface name="wthp_ivi_surface" version="1">
     <description summary="application interface to surface in ivi compositor"/>
 
     <request name="destroy" type="destructor">
-      <description summary="destroy ivi_surface">
+      <description summary="destroy wthp_ivi_surface">
         This removes link from ivi_id to wthp_surface and destroys ivi_surface.
         The ID, ivi_id, is free and can be used for surface_create again.
       </description>
@@ -1589,7 +1589,7 @@
     </event>
   </interface>
 
-  <interface name="ivi_application" version="1">
+  <interface name="wthp_ivi_application" version="1">
     <description summary="create ivi-style surfaces">
       This interface is exposed as a global singleton.
       This interface is implemented by servers that provide IVI-style user interfaces.
@@ -1626,7 +1626,7 @@
       </description>
       <arg name="ivi_id" type="uint"/>
       <arg name="surface" type="object" interface="wthp_surface"/>
-      <arg name="id" type="new_id" interface="ivi_surface"/>
+      <arg name="id" type="new_id" interface="wthp_ivi_surface"/>
     </request>
 
   </interface>

--- a/data/command.xml
+++ b/data/command.xml
@@ -1560,4 +1560,80 @@
     </event>
   </interface>
 
+  <interface name="ivi_surface" version="1">
+    <description summary="application interface to surface in ivi compositor"/>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy ivi_surface">
+        This removes link from ivi_id to wthp_surface and destroys ivi_surface.
+        The ID, ivi_id, is free and can be used for surface_create again.
+      </description>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest resize">
+        The configure event asks the client to resize its surface.
+
+        The size is a hint, in the sense that the client is free to
+        ignore it if it doesn't resize, pick a smaller size (to
+        satisfy aspect ratio or resize in steps of NxM pixels).
+
+        The client is free to dismiss all but the last configure
+        event it received.
+
+        The width and height arguments specify the size of the window
+        in surface-local coordinates.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </event>
+  </interface>
+
+  <interface name="ivi_application" version="1">
+    <description summary="create ivi-style surfaces">
+      This interface is exposed as a global singleton.
+      This interface is implemented by servers that provide IVI-style user interfaces.
+      It allows clients to associate a ivi_surface with wthp_surface.
+    </description>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="given wthp_surface has another role"/>
+      <entry name="ivi_id" value="1" summary="given ivi_id is assigned to another wthp_surface"/>
+    </enum>
+
+    <request name="surface_create">
+      <description summary="create ivi_surface with numeric ID in ivi compositor">
+        This request gives the wthp_surface the role of an IVI Surface. Creating more than
+        one ivi_surface for a wthp_surface is not allowed. Note, that this still allows the
+        following example:
+
+         1. create a wthp_surface
+         2. create ivi_surface for the wthp_surface
+         3. destroy the ivi_surface
+
+        surface_create will create a interface:ivi_surface with numeric ID; ivi_id in
+        ivi compositor. These ivi_ids are defined as unique in the system to identify
+        it inside of ivi compositor. The ivi compositor implements business logic how to
+        set properties of the surface with ivi_id according to status of the system.
+        E.g. a unique ID for Car Navigation application is used for implementing special
+        logic of the application about where it shall be located.
+        The server regards following cases as protocol errors and disconnects the client.
+         - wthp_surface already has an nother role.
+         - ivi_id is already assigned to an another wthp_surface.
+
+        If client destroys ivi_surface or wthp_surface which is assigne to the ivi_surface,
+        ivi_id which is assigned to the ivi_surface is free for reuse.
+      </description>
+      <arg name="ivi_id" type="uint"/>
+      <arg name="surface" type="object" interface="wthp_surface"/>
+      <arg name="id" type="new_id" interface="ivi_surface"/>
+    </request>
+
+  </interface>
+
+  <interface name="dummy" version="1">
+    <request name="dummy_request">
+    </request>
+  </interface>
+
 </protocol>

--- a/src/waltham/header-preamble.txt
+++ b/src/waltham/header-preamble.txt
@@ -48,7 +48,7 @@ struct wthp_seat;
 struct wthp_surface;
 struct wthp_touch;
 
-struct ivi_surface;
-struct ivi_application;
+struct wthp_ivi_surface;
+struct wthp_ivi_application;
 
 struct dummy;

--- a/src/waltham/header-preamble.txt
+++ b/src/waltham/header-preamble.txt
@@ -48,3 +48,7 @@ struct wthp_seat;
 struct wthp_surface;
 struct wthp_touch;
 
+struct ivi_surface;
+struct ivi_application;
+
+struct dummy;

--- a/src/waltham/marshaller.h
+++ b/src/waltham/marshaller.h
@@ -34,6 +34,7 @@
 #include <sys/uio.h>
 #include <sys/un.h>
 #include <errno.h>
+#include <signal.h>
 
 #include "message.h"
 #include "marshaller_log.h"
@@ -42,8 +43,15 @@ static inline int send_all (int sock, const struct iovec *iov, int iovcnt)
 {
    int ret;
 
+   signal(SIGPIPE, SIG_IGN);
+
    do {
-      ret = writev (sock, iov, iovcnt);
+	   ret = writev (sock, iov, iovcnt);
+	   if (errno == EPIPE) {
+		   fprintf(stderr, "send_all %d : %s\n", ret, strerror(errno));
+		   errno = 0;
+		   ret = 0;
+	   }
    } while (ret == -1 && errno == EINTR);
 
    return ret;

--- a/src/waltham/marshaller_log.h
+++ b/src/waltham/marshaller_log.h
@@ -27,10 +27,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <waltham-connection.h>
 
 /* Comment/uncomment to disable/enable debugging log */
 #define DEBUG
 //#define PROFILE
+int debug_message;
 
 #ifdef DEBUG
 static inline void DEBUG_STAMP (void) {
@@ -41,18 +43,22 @@ static inline void DEBUG_STAMP (void) {
    t = time (NULL);
    localtime_r (&t, &tm);
    strftime (str, sizeof str, "%FT%TZ", &tm);
+   if(debug_message == 1)
    printf ("%s ", str);
 }
 
 static inline void DEBUG_TYPE (const char *type) {
+   if(debug_message == 1)
    printf (" %s\n", type);
 }
 
 static inline void STREAM_DEBUG( unsigned char *data, int sz, char *preamble ){
    int itr;
    unsigned char *p = data;
-   for( itr = 0; itr < sz; itr++ ){
-       printf( "%02x", p[itr] );
+   if(debug_message == 1) {
+	   for( itr = 0; itr < sz; itr++ ){
+		   printf( "%02x", p[itr] );
+	   }
    }
 }
 

--- a/src/waltham/waltham-connection.c
+++ b/src/waltham/waltham-connection.c
@@ -38,6 +38,8 @@
 #include "waltham-private.h"
 #include "waltham-util.h"
 
+int debug_message = 0;
+
 struct wth_connection {
 	int fd;
 	enum wth_connection_side side;
@@ -62,11 +64,16 @@ wth_connect_to_server(const char *host, const char *port)
 {
 	struct wth_connection *conn = NULL;
 	int fd;
+	char *debug;
 
 	fd = connect_to_host(host, port);
 
 	if (fd >= 0)
 		conn = wth_connection_from_fd(fd, WTH_CONNECTION_SIDE_CLIENT);
+
+	debug = getenv("WALTHAM_DEBUG");
+	if(debug && (strcmp(debug, "1") == 0))
+	debug_message = 1;
 
 	return conn;
 }

--- a/src/waltham/waltham-connection.h
+++ b/src/waltham/waltham-connection.h
@@ -36,6 +36,8 @@
 extern "C" {
 #endif
 
+extern int debug_message;
+
 /** \file
  *
  * \brief Waltham connection management API

--- a/src/waltham/waltham-util.c
+++ b/src/waltham/waltham-util.c
@@ -34,6 +34,8 @@
 #include "waltham-connection.h"
 #include "waltham-private.h"
 
+int debug_message;
+
 static void
 wth_pfx_print(const char *pfx, const char *fmt, va_list argp)
 {
@@ -49,9 +51,11 @@ wth_debug(const char *fmt, ...)
 {
 	va_list argp;
 
-	va_start(argp, fmt);
-	wth_pfx_print("debug", fmt, argp);
-	va_end(argp);
+	if(debug_message == 1) {
+		va_start(argp, fmt);
+		wth_pfx_print("debug", fmt, argp);
+		va_end(argp);
+	}
 }
 
 void

--- a/tests/server-api-example.c
+++ b/tests/server-api-example.c
@@ -66,6 +66,45 @@ struct compositor {
 	struct wl_list link; /* struct client::compositor_list */
 };
 
+/* wthp_blob_factory protocol object */
+struct blob_factory {
+	struct wthp_blob_factory *obj;
+	struct client *client;
+	struct wl_list link; /* struct client::blob_factory_list */
+};
+
+/* wthp_buffer protocol object */
+struct buffer {
+	struct wthp_buffer *obj;
+	uint32_t data_sz;
+	void *data;
+	int32_t width;
+	int32_t height;
+	int32_t stride;
+	uint32_t format;
+	struct wl_list link; /* struct client::blob_factory_list */
+};
+
+/* wthp_surface protocol object */
+struct surface {
+	struct wthp_surface *obj;
+	uint32_t ivi_id;
+	struct wthp_callback *cb;
+	struct wl_list link; /* struct client::surface_list */
+};
+
+struct ivisurface {
+	struct ivi_surface *obj;
+	struct surface *surf;
+};
+
+/* ivi_application protocol object */
+struct application {
+	struct ivi_application *obj;
+	struct client *client;
+	struct wl_list link; /* struct client::surface_list */
+};
+
 /* wthp_registry protocol object */
 struct registry {
 	struct wthp_registry *obj;
@@ -84,6 +123,9 @@ struct client {
 	struct wl_list registry_list;   /* struct registry::link */
 	struct wl_list compositor_list; /* struct compositor::link */
 	struct wl_list region_list;     /* struct region::link */
+	struct wl_list surface_list;      /* struct surface::link */
+	struct wl_list blob_factory_list; /* struct blob_factory::link */
+	struct wl_list buffer_list; /* struct blob_factory::link */
 };
 
 struct server {
@@ -105,6 +147,261 @@ watch_ctl(struct watch *w, int op, uint32_t events)
 	ee.data.ptr = w;
 	return epoll_ctl(w->server->epoll_fd, op, w->fd, &ee);
 }
+
+/* BEGIN wthp_surface implementation */
+
+static void
+surface_destroy(struct surface *surface)
+{
+        fprintf(stderr, "surface %p destroy\n", surface->obj);
+
+        wthp_surface_free(surface->obj);
+        wl_list_remove(&surface->link);
+        free(surface);
+}
+
+static void
+surface_handle_destroy(struct wthp_surface *wthp_surface)
+{
+	struct surface *surface = wth_object_get_user_data((struct wth_object *)wthp_surface);
+
+	assert(wthp_surface == surface->obj);
+
+	surface_destroy(surface);
+}
+
+static void
+surface_handle_attach(struct wthp_surface *wthp_surface,
+		      struct wthp_buffer *buffer, int32_t x, int32_t y)
+{
+        fprintf(stderr, "surface %p attach(%p, %d, %d)\n",
+                wthp_surface, buffer, x, y);
+
+	wthp_buffer_send_complete(buffer, 0);
+}
+
+static void
+surface_handle_damage(struct wthp_surface *wthp_surface,
+		      int32_t x, int32_t y, int32_t width, int32_t height)
+{
+        fprintf(stderr, "surface %p damage(%d, %d, %d, %d)\n",
+                wthp_surface, x, y, width, height);
+}
+
+static void
+surface_handle_frame(struct wthp_surface *wthp_surface,
+		     struct wthp_callback *callback)
+{
+	struct surface *surface = wth_object_get_user_data((struct wth_object *)wthp_surface);
+        fprintf(stderr, "surface %p callback(%p)\n",
+                wthp_surface, callback);
+
+        surface->cb = callback;
+}
+
+static void
+surface_handle_set_opaque_region(struct wthp_surface *wthp_surface,
+				 struct wthp_region *region)
+{
+        fprintf(stderr, "surface %p set_opaque_region(%p)\n",
+                wthp_surface, region);
+}
+
+static void
+surface_handle_set_input_region(struct wthp_surface *wthp_surface,
+				 struct wthp_region *region)
+{
+        fprintf(stderr, "surface %p set_input_region(%p)\n",
+                wthp_surface, region);
+}
+
+static void
+surface_handle_commit(struct wthp_surface *wthp_surface)
+{
+	struct surface *surface = wth_object_get_user_data((struct wth_object *)wthp_surface);
+        fprintf(stderr, "commit %p\n",
+                wthp_surface);
+
+        wthp_callback_send_done(surface->cb, surface->ivi_id);
+	wthp_callback_free(surface->cb);
+}
+
+static void
+surface_handle_set_buffer_transform(struct wthp_surface *wthp_surface,
+				    int32_t transform)
+{
+        fprintf(stderr, "surface %p et_buffer_transform(%d)\n",
+                wthp_surface, transform);
+}
+
+static void
+surface_handle_set_buffer_scale(struct wthp_surface *wthp_surface,
+				int32_t scale)
+{
+        fprintf(stderr, "surface %p set_buffer_scale(%d)\n",
+                wthp_surface, scale);
+}
+
+static void
+surface_handle_damage_buffer(struct wthp_surface *wthp_surface,
+			     int32_t x, int32_t y, int32_t width, int32_t height)
+{
+        fprintf(stderr, "surface %p damage_buffer(%d, %d, %d, %d)\n",
+                wthp_surface, x, y, width, height);
+}
+
+static const struct wthp_surface_interface surface_implementation = {
+	surface_handle_destroy,
+	surface_handle_attach,
+	surface_handle_damage,
+	surface_handle_frame,
+	surface_handle_set_opaque_region,
+	surface_handle_set_input_region,
+	surface_handle_commit,
+	surface_handle_set_buffer_transform,
+	surface_handle_set_buffer_scale,
+	surface_handle_damage_buffer
+};
+
+/* END wthp_cwsurfaceregion implementation */
+
+/* BEGIN wthp_region implementation */
+
+static void
+buffer_handle_destroy(struct wthp_buffer *wthp_buffer)
+{
+	struct buffer *buf = wth_object_get_user_data((struct wth_object *)wthp_buffer);
+
+	fprintf(stderr, "buffer %p destroy\n", buf->obj);
+
+	wthp_buffer_free(wthp_buffer);
+	wl_list_remove(&buf->link);
+//	free(buf->data);
+	free(buf);
+}
+
+static const struct wthp_buffer_interface buffer_implementation = {
+	buffer_handle_destroy
+};
+
+/* END wthp_region implementation */
+
+/* BEGIN wthp_blob_factory implementation */
+
+static void
+blob_factory_create_buffer(struct wthp_blob_factory *blob_factory,
+			   struct wthp_buffer *wthp_buffer, uint32_t data_sz, void *data,
+			   int32_t width, int32_t height, int32_t stride, uint32_t format)
+{
+	fprintf(stderr, "wthp_blob_factory %p create_buffer(%p, %d, %p, %d, %d, %d, %d)\n",
+		blob_factory, wthp_buffer, data_sz, data, width, height, stride, format);
+
+	struct blob_factory *blob = wth_object_get_user_data((struct wth_object *)blob_factory);
+	struct buffer *buffer;
+
+	buffer = zalloc(sizeof *buffer);
+	if (!buffer) {
+		wth_connection_post_error_no_memory(blob->client->connection);
+		return;
+	}
+
+	wl_list_insert(&blob->client->buffer_list, &buffer->link);
+
+	buffer->data_sz = data_sz;
+	buffer->data = data;
+	buffer->width = width;
+	buffer->height = height;
+	buffer->stride = stride;
+	buffer->format = format;
+	buffer->obj = wthp_buffer;
+
+	wthp_buffer_set_interface(wthp_buffer, &buffer_implementation, buffer);
+}
+
+static const struct wthp_blob_factory_interface blob_factory_implementation = {
+	blob_factory_create_buffer
+};
+
+static void
+client_bind_blob_factory(struct client *c, struct wthp_blob_factory *obj)
+{
+	struct blob_factory *blob;
+
+	blob = zalloc(sizeof *blob);
+	if (!blob) {
+		wth_connection_post_error_no_memory(c->connection);
+		return;
+	}
+
+	blob->obj = obj;
+	blob->client = c;
+	wl_list_insert(&c->compositor_list, &blob->link);
+
+	wthp_blob_factory_set_interface(obj, &blob_factory_implementation,
+					 blob);
+	fprintf(stderr, "client %p bound wthp_blob_factory\n", c);
+}
+
+static void
+ivi_surface_destroy(struct ivi_surface * ivi_surface)
+{
+	struct ivisurface *ivisurf =
+		wth_object_get_user_data((struct wth_object *)ivi_surface);
+	free(ivisurf);
+}
+
+static const struct ivi_surface_interface ivi_surface_implementation = {
+	ivi_surface_destroy
+};
+
+static void
+ivi_surface_create(struct ivi_application * ivi_application, uint32_t ivi_id,
+		   struct wthp_surface * wthp_surface, struct ivi_surface * obj)
+{
+	fprintf(stderr, "ivi_application %p surface_create(%d, %p, %p)\n",
+		ivi_application, ivi_id, wthp_surface, obj);
+	struct surface *surface = wth_object_get_user_data((struct wth_object *)wthp_surface);
+	struct application *app = wth_object_get_user_data((struct wth_object *)ivi_application);
+
+	struct ivisurface *ivisurf;
+
+	ivisurf = zalloc(sizeof *ivisurf);
+	if (!ivisurf) {
+		return;
+	}
+
+	surface->ivi_id = ivi_id;
+	ivisurf->obj = obj;
+	ivisurf->surf = surface;
+
+	ivi_surface_set_interface(obj, &ivi_surface_implementation,
+				  ivisurf);
+}
+
+static const struct ivi_application_interface ivi_application_implementation = {
+	ivi_surface_create
+};
+
+static void
+client_bind_ivi_application(struct client *c, struct ivi_application *obj)
+{
+	struct application *app;
+
+	app = zalloc(sizeof *app);
+	if (!app) {
+		wth_connection_post_error_no_memory(c->connection);
+		return;
+	}
+
+	app->obj = obj;
+	app->client = c;
+	wl_list_insert(&c->compositor_list, &app->link);
+
+	ivi_application_set_interface(obj, &ivi_application_implementation,
+					 app);
+	fprintf(stderr, "client %p bound ivi_application\n", c);
+}
+/* END wthp_blob_factory implementation */
 
 /* BEGIN wthp_region implementation */
 
@@ -169,8 +466,22 @@ static void
 compositor_handle_create_surface(struct wthp_compositor *compositor,
 				 struct wthp_surface *id)
 {
-	wth_object_post_error((struct wth_object *)compositor, 0,
-			      "unimplemented: %s", __func__);
+	struct compositor *comp = wth_object_get_user_data((struct wth_object *)compositor);
+	struct surface *surface;
+
+	fprintf(stderr, "client %p create surface %p\n",
+			comp->client, id);
+
+	surface = zalloc(sizeof *surface);
+	if (!surface) {
+		wth_connection_post_error_no_memory(comp->client->connection);
+		return;
+	}
+
+	surface->obj = id;
+	wl_list_insert(&comp->client->surface_list, &surface->link);
+
+	wthp_surface_set_interface(id, &surface_implementation, surface);
 }
 
 static void
@@ -258,6 +569,10 @@ registry_handle_bind(struct wthp_registry *registry,
 		/* XXX: check version against limits */
 		/* XXX: check that name and interface match */
 		client_bind_compositor(reg->client, (struct wthp_compositor *)id);
+	} else if (strcmp(interface, "wthp_blob_factory") == 0) {
+		client_bind_blob_factory(reg->client, (struct wthp_blob_factory *)id);
+	} else if (strcmp(interface, "ivi_application") == 0) {
+		client_bind_ivi_application(reg->client, (struct ivi_application *)id);
 	} else {
 		wth_object_post_error((struct wth_object *)registry, 0,
 				      "%s: unknown name %u", __func__, name);
@@ -293,6 +608,8 @@ display_handle_get_registry(struct wthp_registry *registry,
 
 	/* XXX: advertise our globals */
 	wthp_registry_send_global(registry, 1, "wthp_compositor", 4);
+	wthp_registry_send_global(registry, 1, "wthp_blob_factory", 4);
+	wthp_registry_send_global(registry, 1, "ivi_application", 1);
 }
 
 static void
@@ -301,6 +618,7 @@ client_destroy(struct client *c)
 	struct region *region;
 	struct compositor *comp;
 	struct registry *reg;
+	struct surface *surface;
 
 	fprintf(stderr, "Client %p disconnected.\n", c);
 
@@ -315,6 +633,9 @@ client_destroy(struct client *c)
 
 	wl_list_last_until_empty(reg, &c->registry_list, link)
 		registry_destroy(reg);
+
+	wl_list_last_until_empty(surface, &c->surface_list, link)
+		surface_destroy(surface);
 
 	wl_list_remove(&c->link);
 	watch_ctl(&c->conn_watch, EPOLL_CTL_DEL, 0);
@@ -400,6 +721,9 @@ client_create(struct server *srv, struct wth_connection *conn)
 	wl_list_init(&c->registry_list);
 	wl_list_init(&c->compositor_list);
 	wl_list_init(&c->region_list);
+	wl_list_init(&c->surface_list);
+	wl_list_init(&c->blob_factory_list);
+	wl_list_init(&c->buffer_list);
 
 	wth_connection_set_registry_callback(conn, display_handle_get_registry, c);
 

--- a/tests/server-api-example.c
+++ b/tests/server-api-example.c
@@ -93,14 +93,15 @@ struct surface {
 	struct wl_list link; /* struct client::surface_list */
 };
 
+/* wthp_ivi_surface protocol object */
 struct ivisurface {
-	struct ivi_surface *obj;
+	struct wthp_ivi_surface *obj;
 	struct surface *surf;
 };
 
-/* ivi_application protocol object */
+/* wthp_ivi_application protocol object */
 struct application {
-	struct ivi_application *obj;
+	struct wthp_ivi_application *obj;
 	struct client *client;
 	struct wl_list link; /* struct client::surface_list */
 };
@@ -219,11 +220,11 @@ static void
 surface_handle_commit(struct wthp_surface *wthp_surface)
 {
 	struct surface *surface = wth_object_get_user_data((struct wth_object *)wthp_surface);
-        fprintf(stderr, "commit %p\n",
-                wthp_surface);
+	fprintf(stderr, "commit %p\n",
+			wthp_surface);
 
-        wthp_callback_send_done(surface->cb, surface->ivi_id);
-	wthp_callback_free(surface->cb);
+	//wthp_callback_send_done(surface->cb, surface->ivi_id);
+	//wthp_callback_free(surface->cb);
 }
 
 static void
@@ -343,22 +344,22 @@ client_bind_blob_factory(struct client *c, struct wthp_blob_factory *obj)
 }
 
 static void
-ivi_surface_destroy(struct ivi_surface * ivi_surface)
+wthp_ivi_surface_destroy(struct wthp_ivi_surface * ivi_surface)
 {
 	struct ivisurface *ivisurf =
 		wth_object_get_user_data((struct wth_object *)ivi_surface);
 	free(ivisurf);
 }
 
-static const struct ivi_surface_interface ivi_surface_implementation = {
-	ivi_surface_destroy
+static const struct wthp_ivi_surface_interface ivi_surface_implementation = {
+	wthp_ivi_surface_destroy
 };
 
 static void
-ivi_surface_create(struct ivi_application * ivi_application, uint32_t ivi_id,
-		   struct wthp_surface * wthp_surface, struct ivi_surface * obj)
+wthp_ivi_application_surface_create(struct wthp_ivi_application * ivi_application, uint32_t ivi_id,
+		   struct wthp_surface * wthp_surface, struct wthp_ivi_surface * obj)
 {
-	fprintf(stderr, "ivi_application %p surface_create(%d, %p, %p)\n",
+	fprintf(stderr, "wthp_ivi_application %p surface_create(%d, %p, %p)\n",
 		ivi_application, ivi_id, wthp_surface, obj);
 	struct surface *surface = wth_object_get_user_data((struct wth_object *)wthp_surface);
 	struct application *app = wth_object_get_user_data((struct wth_object *)ivi_application);
@@ -374,16 +375,16 @@ ivi_surface_create(struct ivi_application * ivi_application, uint32_t ivi_id,
 	ivisurf->obj = obj;
 	ivisurf->surf = surface;
 
-	ivi_surface_set_interface(obj, &ivi_surface_implementation,
+	wthp_ivi_surface_set_interface(obj, &ivi_surface_implementation,
 				  ivisurf);
 }
 
-static const struct ivi_application_interface ivi_application_implementation = {
-	ivi_surface_create
+static const struct wthp_ivi_application_interface wthp_ivi_application_implementation = {
+	wthp_ivi_application_surface_create
 };
 
 static void
-client_bind_ivi_application(struct client *c, struct ivi_application *obj)
+client_bind_wthp_ivi_application(struct client *c, struct wthp_ivi_application *obj)
 {
 	struct application *app;
 
@@ -397,9 +398,9 @@ client_bind_ivi_application(struct client *c, struct ivi_application *obj)
 	app->client = c;
 	wl_list_insert(&c->compositor_list, &app->link);
 
-	ivi_application_set_interface(obj, &ivi_application_implementation,
+	wthp_ivi_application_set_interface(obj, &wthp_ivi_application_implementation,
 					 app);
-	fprintf(stderr, "client %p bound ivi_application\n", c);
+	fprintf(stderr, "client %p bound wthp_ivi_application\n", c);
 }
 /* END wthp_blob_factory implementation */
 
@@ -571,8 +572,8 @@ registry_handle_bind(struct wthp_registry *registry,
 		client_bind_compositor(reg->client, (struct wthp_compositor *)id);
 	} else if (strcmp(interface, "wthp_blob_factory") == 0) {
 		client_bind_blob_factory(reg->client, (struct wthp_blob_factory *)id);
-	} else if (strcmp(interface, "ivi_application") == 0) {
-		client_bind_ivi_application(reg->client, (struct ivi_application *)id);
+	} else if (strcmp(interface, "wthp_ivi_application") == 0) {
+		client_bind_wthp_ivi_application(reg->client, (struct wthp_ivi_application *)id);
 	} else {
 		wth_object_post_error((struct wth_object *)registry, 0,
 				      "%s: unknown name %u", __func__, name);
@@ -609,7 +610,7 @@ display_handle_get_registry(struct wthp_registry *registry,
 	/* XXX: advertise our globals */
 	wthp_registry_send_global(registry, 1, "wthp_compositor", 4);
 	wthp_registry_send_global(registry, 1, "wthp_blob_factory", 4);
-	wthp_registry_send_global(registry, 1, "ivi_application", 1);
+	wthp_registry_send_global(registry, 1, "wthp_ivi_application", 1);
 }
 
 static void


### PR DESCRIPTION
This adds following
- Expansion of protocol by adding wthp_ivi_surface and wthp_ivi_surface interface support.
- debug message: introduce configurable debug message, Enable to switch waltham debug message on/off by environment variable.
- marshaller: Fix when SIGPIPE is caught in send _all(). Avoid to exit with SIGPIPE. This is necessary for retry connection usecase.